### PR TITLE
Calc distancia

### DIFF
--- a/Inc/ecu.h
+++ b/Inc/ecu.h
@@ -78,7 +78,7 @@ void mensagem_CANSPI_recebida(uint16_t id, uint8_t* data);
 int16_t PID_control(int16_t setpoint, int16_t medida);
 void Vel_Calc();
 void Dist_Calc();
-void Odometer(uint16_t rec_dist);
+void Odometer();
 void Diferencial();
 void Diferencial_2();
 int16_t Funcao_Dif();

--- a/Src/ecu.c
+++ b/Src/ecu.c
@@ -870,12 +870,17 @@ void Odometer(uint16_t rec_dist) {
 	const static uint8_t OVERALL_DIST = 1;
 
 	Dist_Calc();							// calculates current distance
-	dist_log[TEST_DIST] += dist_calc;		// updates test and overall distance
-	dist_log[OVERALL_DIST] = rec_dist;		// gets pre existing distance log
-	dist_log[OVERALL_DIST] += dist_calc;	// updates distance already travelled
 
-	Record_Distance(dist_log);				// writes values in flash memory
+	// verifica se o calculo da distancia ja deu 1 metro ou mais - valor retornado em dist_calc esta em decimetro
 
+	if ((dist_calc / 10) >= 1) {
+		dist_log[TEST_DIST] += (dist_calc * 10);		// updates test and overall distance
+		dist_log[OVERALL_DIST] = rec_dist;				// gets pre existing distance log
+		dist_log[OVERALL_DIST] += (dist_calc * 10);		// updates distance already travelled
+
+		// rounds to the nearest meter
+		Record_Distance(dist_log);						// writes values in flash memory
+	}
 }
 
 void Diferencial() {

--- a/Src/ecu.c
+++ b/Src/ecu.c
@@ -106,7 +106,7 @@ uint32_t msgs_recebidas_inversor_ant[2] = { 0, 0};
 extern uint8_t dist_pr;
 extern uint16_t time_speed_refresh;
 extern uint32_t speed_t_total[4];
-extern uint16_t dist_log[];
+extern uint16_t dist_log[2];
 extern uint16_t regen_slc;
 extern uint16_t mode_slc;
 
@@ -854,29 +854,29 @@ void Vel_Calc() //calcula velocidades em rpm, ou decimos de km/h
 	media_diant = (vel_roda[0] + vel_roda[1]) >> 1;
 }
 
-void Dist_Calc() //calcula distancia percorrida desde o inicio do codigo em decimetro
+void Dist_Calc() //calcula o delta de distancia percorrida em 1 segundo e retorna o valor em decimetro
 {
-	if (dist_pr >= 10) {	// faz a conta a cada 1 segundo
+	if (dist_pr >= 10) {	// timer de 1 segundo
 		dist_pr = 0;
 
 		// transforma a velocidade para dm/s e multiplica pelo tempo de execução da main em ms
 		// o tempo eh dividido por 1000 para a unidade de tempo ficar em segundos
-		dist_calc += (media_diant/3.6) * (tempo_final/1000);
+		dist_calc = (media_diant/3.6) * (tempo_final/1000);
 	}
 }
 
-void Odometer(uint16_t rec_dist) {
+void Odometer() {
 	const static uint8_t TEST_DIST = 0;
 	const static uint8_t OVERALL_DIST = 1;
 
-	Dist_Calc();							// calculates current distance
+	// calculates delta
+	Dist_Calc();
 
 	// verifica se o calculo da distancia ja deu 1 metro ou mais - valor retornado em dist_calc esta em decimetro
 
 	if ((dist_calc / 10) >= 1) {
-		dist_log[TEST_DIST] += (dist_calc * 10);		// updates test and overall distance
-		dist_log[OVERALL_DIST] = rec_dist;				// gets pre existing distance log
-		dist_log[OVERALL_DIST] += (dist_calc * 10);		// updates distance already travelled
+		dist_log[TEST_DIST] += (dist_calc / 10);		// updates test and overall distance
+		dist_log[OVERALL_DIST] += (dist_calc / 10);		// updates distance already travelled
 
 		// rounds to the nearest meter
 		Record_Distance(dist_log);						// writes values in flash memory

--- a/Src/ecu.c
+++ b/Src/ecu.c
@@ -854,16 +854,14 @@ void Vel_Calc() //calcula velocidades em rpm, ou decimos de km/h
 	media_diant = (vel_roda[0] + vel_roda[1]) >> 1;
 }
 
-void Dist_Calc() //calcula distancia percorrida desde o inicio do codigo em metros
+void Dist_Calc() //calcula distancia percorrida desde o inicio do codigo em decimetro
 {
-	if (dist_pr >= 10) {
+	if (dist_pr >= 10) {	// faz a conta a cada 1 segundo
 		dist_pr = 0;
-		dist_calc = (dist_calc + media_diant*tempo_final);
 
-		// (1km/h)/10*(s)/1000*k = m
-		//(1000m/3600)/10 *(s) / 1000 * k = m
-		//(m/36000)*(s) / k = m
-		// k = 36000
+		// transforma a velocidade para dm/s e multiplica pelo tempo de execução da main em ms
+		// o tempo eh dividido por 1000 para a unidade de tempo ficar em segundos
+		dist_calc += (media_diant/3.6) * (tempo_final/1000);
 	}
 }
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -30,8 +30,9 @@ extern uint8_t dist_pr;
 extern uint16_t acelerador;
 extern uint16_t funct_flags;
 extern uint32_t tempo_final;
-modos modo_selecionado;
+extern uint16_t dist_log[2];
 
+modos modo_selecionado;
 uint32_t tempo_main_inicial, tempo_final; //variaveis auxiliares para calcular o tempo do loop da main
 uint16_t recorded_dist = 0;
 
@@ -77,6 +78,7 @@ int main(void)
 	Clear_Test_Distance();
 	// gets travelled distance for odometer
 	recorded_dist = Get_Traveled_Distance();
+	dist_log[1] = recorded_dist;
 
 	//      Loop
 	while (true)
@@ -86,8 +88,7 @@ int main(void)
 		le_acelerador(&flag_erro_apps);
 		le_volante();
 		Vel_Calc();
-		// Dist_Calc();								// substituida por Odometro -- eh chamada dentro dela
-		Odometer(recorded_dist);
+		Odometer();
 		//ERS_control();							// em fase de implementacao
 		controle();
 		comando_inversor();


### PR DESCRIPTION
Fórmula de cálculo da distância corrigida os comentários no código explicam as transformações, o contador de 1 segundo continua o mesmo. O valor retornado pela função é em decímetro, por isso, foi necessário fazer umas alterações no odômetro. 
Para conseguir guardar uma distância maior na memória, ao invés de gravar as distâncias em decímetros (que nem faz sentido), coloquei uma condição para apenas gravar quando a distância calculada for maior que 1 metro e então o calculado é multiplicado por 10 para quando gravar, aproximar para o inteiro (metro) mais próximo.