### PR TITLE
Criando Message Queues de 1 elemento para substituir variáveis globais

### DIFF
--- a/Core/Inc/CMSIS_extra/global_variables_handler.h
+++ b/Core/Inc/CMSIS_extra/global_variables_handler.h
@@ -47,22 +47,105 @@ typedef enum {
     THROTTLE_PERCENT,
     BRAKE_STATUS,
     THROTTLE_STATUS,
-    SELECTED_MODE
-} global_vars_message_e;
-
-#define GLOBAL_VARS_QUAN 9
+    SELECTED_MODE,
+    _global_vars_quan /* THIS MUST BE THE LAST ELEMENT OF THE ENUM, AS IT'S USED A NUMBER-OF-ELEMENTS INDICATOR */
+} global_vars_e;
 
 void global_variables_init();
 
-void get_global_var(global_vars_message_e type, void *message);
-void set_global_var(global_vars_message_e type, void *message);
+void get_global_var(global_vars_e type, void *message);
+void set_global_var(global_vars_e type, void *message);
 
+/*
+ * Use the following macros to get/set the global variables without the need of
+ * instantianting another intermediary auxiliary variable.
+ * Keep in mind those are MACROS, not FUNCTIONS! This means that what's defined as
+ * their "implementation body" is actually replaced as-is at the exact spot where the
+ * invocation of the macros themselves happens. For example, the following code:
+ * int main()
+ * {
+ *      int a;
+ *      a = 1;
+ *
+ *      set_global_var_value(THROTTLE_PERCENT, 10);
+ *
+ *      set_global_var_value(THROTTLE_PERCENT, a);
+ *
+ *      THROTTLE_PERCENT_t thr = get_global_var_value(THROTTLE_PERCENT);
+ * }
+ *
+ * would get replaced, during pre-processing stage of compilation, to:
+ * int main()
+ * {
+ *      int a;
+ *      a = 1;
+ *
+ *      {
+ *          THROTTLE_PERCENT_t THROTTLE_PERCENT_var = 10;
+ *          set_global_var(THROTTLE_PERCENT, &(THROTTLE_PERCENT_var));
+ *      }
+ *
+ *      {
+ *          THROTTLE_PERCENT_t THROTTLE_PERCENT_var = a;
+ *          set_global_var(THROTTLE_PERCENT, &(THROTTLE_PERCENT_var));
+ *      }
+ *
+ *      THROTTLE_PERCENT_t thr = ({
+ *                                  THROTTLE_PERCENT_t THROTTLE_PERCENT_var;
+ *                                  get_global_var(THROTTLE_PERCENT, &THROTTLE_PERCENT_var);
+ *                                  THROTTLE_PERCENT_var;
+ *                               });
+ * }
+ *
+ * This means the macros can't be used as 1:1 replacement for functions, as they are simply
+ * rules for code substitution. Care must be taken as to where to call the macros, as the substitution
+ * can lead to undefined behavior.
+ */
+
+/*
+ * set_global_var_value(type, value)
+ * \param[in]   type    the global variable, identified by 'global_vars_e' enum
+ * \param[in]   value   value to be assigned to global variable. Must be convertible
+ *                      to the global variables's defined type.
+ * \return void
+ * \example
+ * if called like 'set_global_var_value(THROTTLE_PERCENT, 100)' – i.e. type=THROTTLE_PERCENT and
+ * value=100 – would get expanded to:
+ *
+ *  {
+ *    THROTTLE_PERCENT_t THROTTLE_PERCENT_var = 100;
+ *    set_global_var(THROTTLE_PERCENT, &(THROTTLE_PERCENT_var));
+ *  }
+ *
+ * The curly braces are there so the code gets executed inside an anonymous temporary
+ * execution block, so it doesn't mess up with the scope where the macro is invoked (by
+ * introducing a new variable whose lifetime is uniquely-dependant on set_global_var call)
+ */
 #define set_global_var_value(type, value)                                      \
     {                                                                          \
         type##_t type##_var = value;                                           \
         set_global_var(type, &(type##_var));                                   \
     }
 
+/*
+ * get_global_var_value(type)
+ * \param[in]   type    the global variable, identified by 'global_vars_e' enum
+ *
+ * \return the current value of the global variable, of type 'type_t' (e.g. type=THROTTLE_PERCENT would yield THROTTLE_PERCENT_t)
+ * \example
+ * if called like 'THROTTLE_PERCENT_t thr = get_global_var_value(THROTTLE_PERCENT)' – i.e.
+ * type=THROTTLE_PERCENT – would get expanded to:
+ *
+ *      THROTTLE_PERCENT_t thr = ({
+ *                                   THROTTLE_PERCENT_t THROTTLE_PERCENT_var;
+ *                                   get_global_var(THROTTLE_PERCENT, &THROTTLE_PERCENT_var);
+ *                                   THROTTLE_PERCENT_var;
+ *                                });
+ *
+ * The '({})' block is a Statement Expression, from GNU C. It allows declarations and statements within an
+ * expression, being the last expression-like statement the "return" value of the expression. This acts like
+ * an anonymous execution block, avoid the pollution of the scope in which the macro was invoked.
+ */
 #define get_global_var_value(type)                                             \
     ({                                                                         \
         type##_t type##_var;                                                   \

--- a/Core/Inc/CMSIS_extra/global_variables_handler.h
+++ b/Core/Inc/CMSIS_extra/global_variables_handler.h
@@ -1,0 +1,73 @@
+/*
+ * global_variables_handler.h
+ *
+ *  Created on: 15 de set de 2021
+ *      Author: renanmoreira
+ */
+
+#ifndef INC_CMSIS_EXTRA_GLOBAL_VARIABLES_HANDLER_H_
+#define INC_CMSIS_EXTRA_GLOBAL_VARIABLES_HANDLER_H_
+
+#include "global_definitions.h"
+#include <stdint.h>
+
+typedef struct {
+    uint16_t speed[2];
+} MOTOR_SPEEDS_t;
+typedef struct {
+    float speed[4];
+} WHEEL_SPEEDS_t;
+typedef uint16_t STEERING_WHEEL_t;
+typedef uint8_t INTERNAL_WHEEL_t;
+typedef race_mode_t RACE_MODE_t;
+typedef uint16_t THROTTLE_PERCENT_t;
+typedef bool BRAKE_STATUS_t;
+typedef bool THROTTLE_STATUS_t;
+typedef modos SELECTED_MODE_t;
+
+#define MOTOR_SPEEDS_DEFAULT_VALUE                                             \
+    { 0, 0 }
+#define WHEEL_SPEEDS_DEFAULT_VALUE                                             \
+    { 0, 0, 0, 0 }
+#define STEERING_WHEEL_DEFAULT_VALUE 0
+#define INTERNAL_WHEEL_DEFAULT_VALUE 0
+#define RACE_MODE_DEFAULT_VALUE ENDURO
+#define THROTTLE_PERCENT_DEFAULT_VALUE 0
+#define BRAKE_STATUS_DEFAULT_VALUE false
+#define THROTTLE_STATUS_DEFAULT_VALUE false
+#define SELECTED_MODE_DEFAULT_VALUE                                            \
+    {}
+
+typedef enum {
+    MOTOR_SPEEDS,
+    WHEEL_SPEEDS,
+    STEERING_WHEEL,
+    INTERNAL_WHEEL,
+    RACE_MODE,
+    THROTTLE_PERCENT,
+    BRAKE_STATUS,
+    THROTTLE_STATUS,
+    SELECTED_MODE
+} global_vars_message_e;
+
+#define GLOBAL_VARS_QUAN 9
+
+void global_variables_init();
+
+void get_global_var(global_vars_message_e type, void *message);
+void set_global_var(global_vars_message_e type, void *message);
+
+#define set_global_var_value(type, value)                                      \
+    {                                                                          \
+        type##_t type##_var = value;                                           \
+        set_global_var(type, &(type##_var));                                   \
+    }
+
+#define get_global_var_value(type)                                             \
+    ({                                                                         \
+        type##_t type##_var;                                                   \
+        get_global_var(type, &type##_var);                                     \
+        type##_var;                                                            \
+    })
+
+#endif /* INC_CMSIS_EXTRA_GLOBAL_VARIABLES_HANDLER_H_ */

--- a/Core/Inc/global_variables.h
+++ b/Core/Inc/global_variables.h
@@ -10,26 +10,8 @@
 
 #include "global_definitions.h"
 
-//velocidade de cada roda individualmente
-extern volatile float g_wheel_speed[4];
-
-//velocidade do motor
-extern volatile uint16_t g_motor_speed[2];
-
-//modo atual de corrida
-extern volatile race_mode_t g_race_mode;
-
 //buffer atualizado pelo DMA com dados de leitura do ADC
 extern volatile uint16_t ADC_DMA_buffer[ADC_LINES];
-
-//porcentagem do curso do pedal
-extern volatile uint16_t throttle_percent;
-
-//status do freio, 1 = ativado e 0 = desativado
-extern volatile bool is_brake_active;
-
-//status do apps, 1 = acionado e 0 = desativado
-extern volatile bool is_throttle_active;
 
 //variavel de controle para desabilitar referência de torque
 extern volatile uint8_t g_should_disable_engines;
@@ -38,15 +20,8 @@ extern volatile uint8_t g_should_disable_engines;
 extern volatile vehicle_state_parameters_t g_vehicle_state_parameters;
 
 extern modos aceleracao, skidpad, autox, enduro, reverse, erro;
-extern modos modo_selecionado;
 
 //guarda o estado atual do veículo (acelera, neutro, freia)
 extern volatile vehicle_state_e vehicle_state;
-
-//roda interna atual
-extern volatile uint8_t internal_wheel;
-
-//estercamento do volante
-extern volatile uint16_t steering_wheel;
 
 #endif /* INC_GLOBAL_VARIABLES_H_ */

--- a/Core/Src/CMSIS_extra/cmsis_extra.c
+++ b/Core/Src/CMSIS_extra/cmsis_extra.c
@@ -9,6 +9,11 @@
 
 #include "FreeRTOS.h"
 #include "queue.h"
+#include "cmsis_gcc.h"
+
+#define IS_IRQ_MODE()             (__get_IPSR() != 0U)
+
+#define IS_IRQ()                  IS_IRQ_MODE()
 
 osStatus_t osMessageQueuePutOverwrite(osMessageQueueId_t mq_id,
                                       const void *msg_ptr, uint8_t msg_prio) {

--- a/Core/Src/CMSIS_extra/global_variables_handler.c
+++ b/Core/Src/CMSIS_extra/global_variables_handler.c
@@ -1,0 +1,50 @@
+/*
+ * global_variables_handler.c
+ *
+ *  Created on: 15 de set de 2021
+ *      Author: renanmoreira
+ */
+
+#include "CMSIS_extra/global_variables_handler.h"
+
+#include "CMSIS_extra/cmsis_extra.h"
+#include "cmsis_os2.h"
+
+typedef struct {
+    osMessageQueueId_t id;
+    osMessageQueueAttr_t attr;
+} global_variable_message_queue_data_t;
+
+// create local storage of queue infos
+static global_variable_message_queue_data_t queues_info[GLOBAL_VARS_QUAN];
+
+#define INSTANTIATE_GLOBAL_VAR_QUEUE(var_name)                                 \
+    global_variable_message_queue_data_t *var_name##_info =                    \
+        queues_info + var_name;                                                \
+    var_name##_info->attr = (osMessageQueueAttr_t){.name = "q_" #var_name};    \
+    var_name##_info->id = osMessageQueueNew(/*size=*/1, sizeof(var_name##_t),  \
+                                            &var_name##_info->attr);           \
+    var_name##_t var_name##_msg = (var_name##_t)var_name##_DEFAULT_VALUE;      \
+    osMessageQueuePut(var_name##_info->id, &var_name##_msg, 0, 0);
+
+void global_variables_init() {
+
+    // instantiating single-element message queues for each global variable
+    INSTANTIATE_GLOBAL_VAR_QUEUE(MOTOR_SPEEDS);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(WHEEL_SPEEDS);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(STEERING_WHEEL);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(INTERNAL_WHEEL);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(RACE_MODE);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(THROTTLE_PERCENT);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(BRAKE_STATUS);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(THROTTLE_STATUS);
+    INSTANTIATE_GLOBAL_VAR_QUEUE(SELECTED_MODE);
+}
+
+void get_global_var(global_vars_message_e type, void *message) {
+    osMessageQueuePeek(queues_info[type].id, message, 0, 0);
+}
+
+void set_global_var(global_vars_message_e type, void *message) {
+    osMessageQueuePutOverwrite(queues_info[type].id, message, 0);
+}

--- a/Core/Src/CMSIS_extra/global_variables_handler.c
+++ b/Core/Src/CMSIS_extra/global_variables_handler.c
@@ -30,7 +30,7 @@ static global_variable_message_queue_data_t queues_info[_global_vars_quan];
  * THROTTLE_PERCENT_info->attr = (osMessageQueueAttr_t){.name = "q_THROTTLE_PERCENT"};
  * THROTTLE_PERCENT_info->id = osMessageQueueNew(1, sizeof(THROTTLE_PERCENT_t), &THROTTLE_PERCENT_info->attr); THROTTLE_PERCENT_t
  * THROTTLE_PERCENT_msg = (THROTTLE_PERCENT_t)THROTTLE_PERCENT_DEFAULT_VALUE;
- * osMessageQueuePut(var_name##_info->id, &var_name##_msg, 0, 0);
+ * osMessageQueuePut(THROTTLE_PERCENT_info->id, &THROTTLE_PERCENT_msg, 0, 0);
  */
 #define INSTANTIATE_GLOBAL_VAR_QUEUE(var_name)                                 \
     /* get a pointer to the queue_data struct intance at position var_name*/   \

--- a/Core/Src/CMSIS_extra/global_variables_handler.c
+++ b/Core/Src/CMSIS_extra/global_variables_handler.c
@@ -16,15 +16,36 @@ typedef struct {
 } global_variable_message_queue_data_t;
 
 // create local storage of queue infos
-static global_variable_message_queue_data_t queues_info[GLOBAL_VARS_QUAN];
+static global_variable_message_queue_data_t queues_info[_global_vars_quan];
 
+/*
+ * This macro creates a Message Queue of size 1, based on the name provided by
+ * var_name parameter. The Message Queue Id is then stored in the array
+ * queues_info, at the position identified by the integer value from the enum
+ * named var_name (e.g. var_name=THROTTLE_PERCENT would translate to enum
+ * THROTTLE_PERCENT, defined in global_vars_e). The call
+ * 'INSTANTIATE_GLOBAL_VAR_QUEUE(THROTTLE_PERCENT)' would get expanded to:
+ *
+ * global_variable_message_queue_data_t *THROTTLE_PERCENT_info = queues_info + var_name;
+ * THROTTLE_PERCENT_info->attr = (osMessageQueueAttr_t){.name = "q_THROTTLE_PERCENT"};
+ * THROTTLE_PERCENT_info->id = osMessageQueueNew(1, sizeof(THROTTLE_PERCENT_t), &THROTTLE_PERCENT_info->attr); THROTTLE_PERCENT_t
+ * THROTTLE_PERCENT_msg = (THROTTLE_PERCENT_t)THROTTLE_PERCENT_DEFAULT_VALUE;
+ * osMessageQueuePut(var_name##_info->id, &var_name##_msg, 0, 0);
+ */
 #define INSTANTIATE_GLOBAL_VAR_QUEUE(var_name)                                 \
+    /* get a pointer to the queue_data struct intance at position var_name*/   \
     global_variable_message_queue_data_t *var_name##_info =                    \
         queues_info + var_name;                                                \
+    /* defines queue name as q_var_name */                                     \
     var_name##_info->attr = (osMessageQueueAttr_t){.name = "q_" #var_name};    \
+    /* create queue of size 1, storing the queue id in the pointer created     \
+     * previously */                                                           \
     var_name##_info->id = osMessageQueueNew(/*size=*/1, sizeof(var_name##_t),  \
                                             &var_name##_info->attr);           \
+    /* fetch var default value defined in the header file, storing it in a     \
+     * temp var*/                                                              \
     var_name##_t var_name##_msg = (var_name##_t)var_name##_DEFAULT_VALUE;      \
+    /* place this value in the queue */                                        \
     osMessageQueuePut(var_name##_info->id, &var_name##_msg, 0, 0);
 
 void global_variables_init() {
@@ -41,10 +62,10 @@ void global_variables_init() {
     INSTANTIATE_GLOBAL_VAR_QUEUE(SELECTED_MODE);
 }
 
-void get_global_var(global_vars_message_e type, void *message) {
+void get_global_var(global_vars_e type, void *message) {
     osMessageQueuePeek(queues_info[type].id, message, 0, 0);
 }
 
-void set_global_var(global_vars_message_e type, void *message) {
+void set_global_var(global_vars_e type, void *message) {
     osMessageQueuePutOverwrite(queues_info[type].id, message, 0);
 }

--- a/Core/Src/RTD.c
+++ b/Core/Src/RTD.c
@@ -62,9 +62,7 @@ bool can_RTD_be_enabled() {
 
 void set_RTD() {
     osEventFlagsSet(ECU_control_event_id, RTD_FLAG);                                         //Seta flag de RTD
-    SELECTED_MODE_t selected_mode;
-    get_global_var(SELECTED_MODE, &selected_mode);
-    set_rgb_led(selected_mode.cor, FIXED);
+    set_rgb_led(get_global_var_value(SELECTED_MODE).cor, FIXED);
     aciona_sirene();
 }
 

--- a/Core/Src/RTD.c
+++ b/Core/Src/RTD.c
@@ -23,7 +23,7 @@ void RTD(void *argument) {
     SELECTED_MODE_t selected_mode;
     get_global_var(SELECTED_MODE, &selected_mode);
     //seta o led rgb no primeira execução do código
-    set_rgb_led(selected_mode.cor, BLINK200);
+    set_rgb_led(get_global_var_value(THROTTLE_PERCENT).cor, BLINK200);
 
     for(;;) {
 

--- a/Core/Src/RTD.c
+++ b/Core/Src/RTD.c
@@ -20,10 +20,8 @@ bool can_RTD_be_enabled();
 void set_RTD();
 
 void RTD(void *argument) {
-    SELECTED_MODE_t selected_mode;
-    get_global_var(SELECTED_MODE, &selected_mode);
     //seta o led rgb no primeira execução do código
-    set_rgb_led(get_global_var_value(THROTTLE_PERCENT).cor, BLINK200);
+    set_rgb_led(get_global_var_value(SELECTED_MODE).cor, BLINK200);
 
     for(;;) {
 

--- a/Core/Src/RTD.c
+++ b/Core/Src/RTD.c
@@ -13,15 +13,17 @@
 #include "debugleds.h"
 #include "stdbool.h"
 #include "util.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 void aciona_sirene();
 bool can_RTD_be_enabled();
 void set_RTD();
 
 void RTD(void *argument) {
-
+    SELECTED_MODE_t selected_mode;
+    get_global_var(SELECTED_MODE, &selected_mode);
     //seta o led rgb no primeira execução do código
-    set_rgb_led(modo_selecionado.cor, BLINK200);
+    set_rgb_led(selected_mode.cor, BLINK200);
 
     for(;;) {
 
@@ -40,16 +42,19 @@ void RTD(void *argument) {
 
 
 void exit_RTD() {
-    modo_selecionado = erro;                            //seta modo_selecionado como erro
-    g_race_mode = ERRO;
-    set_rgb_led(modo_selecionado.cor, BLINK200);
+    set_global_var_value(SELECTED_MODE, erro);          //seta modo_selecionado como erro
+    set_global_var_value(RACE_MODE, ERRO);
+    set_rgb_led(get_global_var_value(SELECTED_MODE).cor, BLINK200);
     osEventFlagsClear(ECU_control_event_id, RTD_FLAG);  //limpa flag de RTD
 }
 
 bool can_RTD_be_enabled() {
     uint32_t error_flags = osEventFlagsGet(ECU_control_event_id);                           //obtem todas as flags
     error_flags &= ALL_SEVERE_ERROR_FLAG;                                                   //filtra apenas flags de erros severos, ignorando as outras
-    if(is_brake_active && !is_throttle_active && !error_flags && (g_race_mode != ERRO))
+    BRAKE_STATUS_t is_brake_active = get_global_var_value(BRAKE_STATUS);
+    THROTTLE_STATUS_t is_throttle_active = get_global_var_value(THROTTLE_STATUS);
+    RACE_MODE_t race_mode = get_global_var_value(RACE_MODE);
+    if(is_brake_active && !is_throttle_active && !error_flags && (race_mode != ERRO))
         return true;
     else
         return false;
@@ -57,7 +62,9 @@ bool can_RTD_be_enabled() {
 
 void set_RTD() {
     osEventFlagsSet(ECU_control_event_id, RTD_FLAG);                                         //Seta flag de RTD
-    set_rgb_led(modo_selecionado.cor, FIXED);
+    SELECTED_MODE_t selected_mode;
+    get_global_var(SELECTED_MODE, &selected_mode);
+    set_rgb_led(selected_mode.cor, FIXED);
     aciona_sirene();
 }
 

--- a/Core/Src/controle.c
+++ b/Core/Src/controle.c
@@ -12,6 +12,7 @@
 #include "datalog_handler.h"
 #include "global_instances.h"
 #include "util.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 
 
@@ -19,8 +20,6 @@ void update_regen_state(vehicle_state_e vehicle_state);
 
 extern osMutexId_t m_state_parameter_mutexHandle;
 extern osMessageQueueId_t q_ref_torque_messageHandle;
-extern volatile uint16_t g_motor_speed[2];
-extern volatile uint16_t throttle_percent;
 
 volatile vehicle_state_parameters_t g_vehicle_state_parameters;
 
@@ -30,9 +29,9 @@ volatile vehicle_state_e vehicle_state;
 void update_state(bool disable) {
 	if (disable == true)
 		vehicle_state = S_DISABLE_E;
-	else if ((throttle_percent < 100) && (frenagem_regenerativa == true) && g_motor_speed[L_MOTOR] > _5_kmph_rpm)
+	else if ((get_global_var_value(THROTTLE_PERCENT) < 100) && (frenagem_regenerativa == true) && get_global_var_value(MOTOR_SPEEDS).speed[L_MOTOR] > _5_kmph_rpm)
 	    vehicle_state = S_BRAKE_E;
-	else if(throttle_percent > 100)
+	else if(get_global_var_value(THROTTLE_PERCENT)  > 100)
 		vehicle_state = S_ACCELERATE_E;
 	else
 		vehicle_state = S_NEUTER_E;
@@ -42,22 +41,24 @@ void update_state(bool disable) {
 
 void update_state_parameters(torque_message_t* torque_message) {
 
+	SELECTED_MODE_t selected_mode = get_global_var_value(SELECTED_MODE);
 	switch(vehicle_state) {
 		case S_NEUTER_E:
 			set_bit8(&torque_message->parameters, P_ENABLE, true);
 			set_bit8(&torque_message->parameters, P_BRAKE, false);
 			//TODO: mudar velocidade do motor de acordo com nova logica
-			set_bit8(&torque_message->parameters, P_RUNSTOP, (g_motor_speed[R_MOTOR] > _5_kmph_rpm || g_motor_speed[L_MOTOR] > _5_kmph_rpm));
+			MOTOR_SPEEDS_t motor_speeds = get_global_var_value(MOTOR_SPEEDS);
+			set_bit8(&torque_message->parameters, P_RUNSTOP, (motor_speeds.speed[R_MOTOR] > _5_kmph_rpm || motor_speeds.speed[L_MOTOR] > _5_kmph_rpm));
 			torque_message->torque_ref[R_MOTOR] = 0;
 			torque_message->torque_ref[L_MOTOR] = 0;
 			torque_message->neg_torque_ref[R_MOTOR] = 0;
 			torque_message->neg_torque_ref[L_MOTOR] = 0;
-			torque_message->speed_ref[R_MOTOR] = modo_selecionado.vel_max;
-			torque_message->speed_ref[L_MOTOR] = modo_selecionado.vel_max;
+			torque_message->speed_ref[R_MOTOR] = selected_mode.vel_max;
+			torque_message->speed_ref[L_MOTOR] = selected_mode.vel_max;
 			break;
 		case S_BRAKE_E:
 			set_bit8(&torque_message->parameters, P_ENABLE, true);
-			set_bit8(&torque_message->parameters, P_BRAKE, modo_selecionado.freio_regen);
+			set_bit8(&torque_message->parameters, P_BRAKE, selected_mode.freio_regen);
 			set_bit8(&torque_message->parameters, P_RUNSTOP, true);
 			torque_message->torque_ref[R_MOTOR] = 0;
 			torque_message->torque_ref[L_MOTOR] = 0;
@@ -73,8 +74,8 @@ void update_state_parameters(torque_message_t* torque_message) {
 			//TODO: Mudar para nova lógica de envio de mensagem de torque ao inversor
 			torque_message->neg_torque_ref[R_MOTOR] = 0;
 			torque_message->neg_torque_ref[L_MOTOR] = 0;
-			torque_message->speed_ref[R_MOTOR] = modo_selecionado.vel_max;
-			torque_message->speed_ref[L_MOTOR] = modo_selecionado.vel_max;
+			torque_message->speed_ref[R_MOTOR] = selected_mode.vel_max;
+			torque_message->speed_ref[L_MOTOR] = selected_mode.vel_max;
 
 			//if (modo_selecionado.traction_control == true) tc_system();
 			//else torque_vectoring();

--- a/Core/Src/external_interrupt_handler.c
+++ b/Core/Src/external_interrupt_handler.c
@@ -9,12 +9,12 @@
 #include "main.h"
 #include "speed_calc.h"
 #include "global_instances.h"
-#include "global_variables.h"
 #include "global_definitions.h"
 #include "cmsis_os.h"
 #include "util.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
-speed_message_t speed_message;
+static speed_message_t speed_message;
 
 //implementa a funcao homonima da HAL, que trata interrupcao por pino
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin){
@@ -33,8 +33,9 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin){
 			osThreadFlagsSet(t_RTDHandle, RTD_BTN_PRESSED_FLAG);
 			break;
 
-		case B_MODO_Pin:
-			g_race_mode++;
+		case B_MODO_Pin: ;
+			RACE_MODE_t race_mode = get_global_var_value(RACE_MODE);
+			set_global_var_value(RACE_MODE, race_mode+1);
 			osThreadFlagsSet(t_seleciona_modoHandle, MODE_BTN_PRESSED_FLAG);
 			break;
 

--- a/Core/Src/global_variables.c
+++ b/Core/Src/global_variables.c
@@ -8,16 +8,7 @@
 
 #include "global_variables.h"
 
-volatile uint16_t g_motor_speed[2];
-
-volatile race_mode_t g_race_mode = ENDURO;
-
 volatile uint16_t ADC_DMA_buffer[ADC_LINES];
-
-volatile uint16_t throttle_percent = 0;
-volatile bool is_brake_active = 0;
-volatile bool is_throttle_active = 0;
 
 modos aceleracao, skidpad, autox, enduro, reverse, erro;
 
-modos modo_selecionado;

--- a/Core/Src/initializers.c
+++ b/Core/Src/initializers.c
@@ -15,6 +15,7 @@
 #include "CAN/general_can.h"
 #include "CAN/CAN_IDs.h"
 #include "constants.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 //inicializa prioridade dos ISRs para permitir chamada da API do RTOS de dentro dos ISRs mantendo a prioridade máxima de ISRs
 void init_NVIC_priorities() {
@@ -37,8 +38,6 @@ cores_t led_conf;
 
 uint8_t error_count = 0; // conta erros, quantas vezes o programa caiu no error handler
 uint16_t debug_milis =0, debug_milis_ant = 0;
-
-extern modos modo_selecionado;
 
 
 extern FDCAN_HandleTypeDef hfdcan1;
@@ -115,7 +114,6 @@ void inicializa_modos() {
 	erro.mode = ERRO;
 	erro.cor = VERMELHO;
 
-
-	modo_selecionado = enduro; //inicializa no modo enduro
+	set_global_var_value(SELECTED_MODE, enduro); //inicializa no modo enduro
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -32,6 +32,7 @@
 #include "main_task.h"
 #include "debugleds.h"
 #include "rgb_led.h"
+#include "CMSIS_extra/global_variables_handler.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -289,7 +290,6 @@ int main(void)
 	}
   init_ADC_DMA(&hadc1);
   init_CAN();
-  inicializa_modos();
   HAL_TIM_Base_Start(&htim2);
   /* USER CODE END 2 */
 
@@ -335,6 +335,8 @@ int main(void)
 
   /* USER CODE BEGIN RTOS_QUEUES */
   /* add queues, ... */
+  global_variables_init();
+  inicializa_modos(); // must be initialized after global variables
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */

--- a/Core/Src/main_task.c
+++ b/Core/Src/main_task.c
@@ -14,6 +14,7 @@
 #include "rgb_led.h"
 #include "throttle.h"
 #include "util.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 
 
@@ -66,7 +67,7 @@ void main_task(void *argument) {
                     osDelay(20);
                 } else {                                                                //caso o erro tenha sido resolvido:
                     osThreadFlagsClear(APPS_ERROR_FLAG);                                //limpa flag de thread do erro
-                    set_rgb_led(modo_selecionado.cor, NO_CHANGE);                       //retorna o RGB ao funcionamento normal
+                    set_rgb_led(get_global_var_value(SELECTED_MODE).cor, NO_CHANGE);    //retorna o RGB ao funcionamento normal
                     osEventFlagsSet(ECU_control_event_id, THROTTLE_AVAILABLE_FLAG);     //seta a flag que permite o funcionamento do pedal
                 }
                 break;
@@ -79,7 +80,7 @@ void main_task(void *argument) {
                     osDelay(20);
                 } else {                                                                //caso o erro tenha sido resolvido:
                     osThreadFlagsClear(BSE_ERROR_FLAG);                                 //limpa flag de thread do erro
-                    set_rgb_led(modo_selecionado.cor, NO_CHANGE);                       //retorna o RGB ao funcionamento normal
+                    set_rgb_led(get_global_var_value(SELECTED_MODE).cor, NO_CHANGE);    //retorna o RGB ao funcionamento normal
                     osEventFlagsSet(ECU_control_event_id, THROTTLE_AVAILABLE_FLAG);     //seta a flag que permite o funcionamento do pedal
                 }
                 break;

--- a/Core/Src/modo.c
+++ b/Core/Src/modo.c
@@ -36,7 +36,6 @@ void seleciona_modo(void *argument) {
                 set_global_var(RACE_MODE, &race_mode);
             }
 
-            SELECTED_MODE_t selected_mode;
             switch(race_mode) {
                 case ENDURO:
                     set_global_var_value(SELECTED_MODE, enduro);
@@ -55,7 +54,7 @@ void seleciona_modo(void *argument) {
                     break;
                 }
 
-            set_rgb_led(selected_mode.cor, BLINK200);
+            set_rgb_led(get_global_var_value(SELECTED_MODE).cor, BLINK200);
 
         }
         //todo: dataloggar modos

--- a/Core/Src/modo.c
+++ b/Core/Src/modo.c
@@ -12,7 +12,7 @@
 #include "global_instances.h"
 #include "rgb_led.h"
 #include "util.h"
-
+#include "CMSIS_extra/global_variables_handler.h"
 
 
 void seleciona_modo(void *argument) {
@@ -28,29 +28,34 @@ void seleciona_modo(void *argument) {
 
         bool is_RTD_active = get_individual_flag(ECU_control_event_id, RTD_FLAG);
         if (!is_RTD_active) {
+            RACE_MODE_t race_mode;
+            get_global_var(RACE_MODE, &race_mode);
+            if (race_mode > AUTOX)
+            {
+                race_mode = ENDURO;
+                set_global_var(RACE_MODE, &race_mode);
+            }
 
-            if (g_race_mode > AUTOX)
-                g_race_mode = ENDURO;
-
-            switch(g_race_mode) {
+            SELECTED_MODE_t selected_mode;
+            switch(race_mode) {
                 case ENDURO:
-                    modo_selecionado = enduro;
+                    set_global_var_value(SELECTED_MODE, enduro);
                     break;
                 case ACELERACAO:
-                    modo_selecionado = aceleracao;
+                    set_global_var_value(SELECTED_MODE, aceleracao);
                     break;
                 case SKIDPAD:
-                    modo_selecionado = skidpad;
+                    set_global_var_value(SELECTED_MODE, skidpad);
                     break;
                 case AUTOX:
-                    modo_selecionado = autox;
+                    set_global_var_value(SELECTED_MODE, autox);
                     break;
                 default:
-                    modo_selecionado = erro;
+                    set_global_var_value(SELECTED_MODE, erro);
                     break;
                 }
 
-            set_rgb_led(modo_selecionado.cor, BLINK200);
+            set_rgb_led(selected_mode.cor, BLINK200);
 
         }
         //todo: dataloggar modos

--- a/Core/Src/modo.c
+++ b/Core/Src/modo.c
@@ -33,7 +33,7 @@ void seleciona_modo(void *argument) {
                 set_global_var_value(RACE_MODE, ENDURO);
             }
 
-            switch(race_mode) {
+            switch(get_global_var_value(RACE_MODE)) {
                 case ENDURO:
                     set_global_var_value(SELECTED_MODE, enduro);
                     break;

--- a/Core/Src/modo.c
+++ b/Core/Src/modo.c
@@ -28,12 +28,9 @@ void seleciona_modo(void *argument) {
 
         bool is_RTD_active = get_individual_flag(ECU_control_event_id, RTD_FLAG);
         if (!is_RTD_active) {
-            RACE_MODE_t race_mode;
-            get_global_var(RACE_MODE, &race_mode);
-            if (race_mode > AUTOX)
+            if (get_global_var_value(RACE_MODE) > AUTOX)
             {
-                race_mode = ENDURO;
-                set_global_var(RACE_MODE, &race_mode);
+                set_global_var_value(RACE_MODE, ENDURO);
             }
 
             switch(race_mode) {

--- a/Core/Src/speed_calc.c
+++ b/Core/Src/speed_calc.c
@@ -100,6 +100,6 @@ void reset_speed_single(speed_message_t* message, speed_message_t* last_messages
 		if((message->tim_count - last_messages[i].tim_count) > min_count)
 		{
 			wheel_speeds.speed[i] = 0;
-			set_global_var(WHEEL_SPEEDS, &wheel_speeds);
 		}
+	set_global_var(WHEEL_SPEEDS, &wheel_speeds);
 }

--- a/Core/Src/steering.c
+++ b/Core/Src/steering.c
@@ -9,12 +9,9 @@
 #include "constants.h"
 #include "global_definitions.h"
 #include "datalog_handler.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 extern volatile uint16_t ADC_DMA_buffer[ADC_LINES];
-
-volatile uint8_t internal_wheel;
-volatile uint16_t steering_wheel;
-
 
 void steering_read(void *argument) {
 	uint16_t volante_cru;
@@ -41,24 +38,24 @@ void steering_read(void *argument) {
 
 
 		if (volante_cru < zero_aux) {
-			steering_wheel = 0;
+			set_global_var_value(STEERING_WHEEL, 0);
 		}
 		else{
-			steering_wheel = volante_cru * GANHO_VOLANTE - ZERO_VOLANTE;
+			set_global_var_value(STEERING_WHEEL, volante_cru * GANHO_VOLANTE - ZERO_VOLANTE);
 		}
+
+		STEERING_WHEEL_t steering_wheel = get_global_var_value(STEERING_WHEEL);
 
 		log_data(ID_STEERING_WHEEL, steering_wheel);
 
 		//SPAN_ALINHAMENTO é apenas um span pra ainda considerar o volante no centro
 		//até uma certa quantidade
-		if(steering_wheel > VOLANTE_ALINHADO + SPAN_ALINHAMENTO){
-			internal_wheel = ESQUERDA;
-		}
-		else if(steering_wheel < VOLANTE_ALINHADO - SPAN_ALINHAMENTO){
-			internal_wheel = DIREITA;
-		}
-		else{
-			internal_wheel = CENTRO;
+		if(steering_wheel > VOLANTE_ALINHADO + SPAN_ALINHAMENTO) {
+			set_global_var_value(INTERNAL_WHEEL, ESQUERDA);
+		} else if(steering_wheel < VOLANTE_ALINHADO - SPAN_ALINHAMENTO) {
+			set_global_var_value(INTERNAL_WHEEL, DIREITA);
+		} else {
+			set_global_var_value(INTERNAL_WHEEL, CENTRO);
 		}
 
 		osDelay(100);

--- a/Core/Src/throttle.c
+++ b/Core/Src/throttle.c
@@ -8,6 +8,7 @@
 #include "throttle.h"
 #include "datalog_handler.h"
 #include "error_treatment.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
 uint16_t calculate_expected_apps1_from_apps2(uint16_t apps2_throttle_percent);
 uint16_t calculate_apps2(uint16_t APPS2);
@@ -38,10 +39,10 @@ void throttle_read(void *argument) {
 
         apps2_throttle_percent = calculate_apps2(APPS2);                      //calcula a porcentagem do pedal a partir do APPS2
 
-        is_brake_active = (BSE > BRAKE_ACTIVE);
-        is_throttle_active = (apps2_throttle_percent > 0);
+        set_global_var_value(BRAKE_STATUS, (BSE > BRAKE_ACTIVE));
+        set_global_var_value(THROTTLE_STATUS, (apps2_throttle_percent > 0));
 
-        log_data(ID_BRAKE, is_brake_active);
+        log_data(ID_BRAKE, get_global_var_value(BRAKE_STATUS));
 
         check_for_errors(check_for_APPS_errors, APPS_ERROR_FLAG);           //verifica a plausabilidade dos APPSs
         check_for_errors(check_for_BSE_errors, BSE_ERROR_FLAG);             //verifica a plausabilidade do BSE

--- a/Core/Src/throttle_control.c
+++ b/Core/Src/throttle_control.c
@@ -12,8 +12,7 @@
 #include "global_instances.h"
 #include "datalog_handler.h"
 #include "util.h"
-
-extern volatile uint16_t throttle_percent;
+#include "CMSIS_extra/global_variables_handler.h"
 
 void throttle_control(void *argument) {
     for(;;) {
@@ -26,10 +25,14 @@ void throttle_control(void *argument) {
         bool is_throttle_active = get_individual_flag(ECU_control_event_id, THROTTLE_AVAILABLE_FLAG);
 
         if (is_RTD_active && is_throttle_active)
-            throttle_percent = message;
+        {
+            set_global_var_value(THROTTLE_PERCENT, message);
+        }
         else
-            throttle_percent = 0;
+        {
+            set_global_var_value(THROTTLE_PERCENT, 0);
+        }
 
-        log_data(ID_THROTTLE, throttle_percent);
+        log_data(ID_THROTTLE, get_global_var_value(THROTTLE_PERCENT));
     }
 }

--- a/Core/Src/torque_manager.c
+++ b/Core/Src/torque_manager.c
@@ -9,13 +9,10 @@
 #include "cmsis_os.h"
 #include "global_definitions.h"
 #include "stdint.h"
+#include "CMSIS_extra/global_variables_handler.h"
 
-extern volatile uint16_t throttle_percent;
-extern modos modo_selecionado;
 extern osMessageQueueId_t q_ref_torque_messageHandle;
 extern osMutexId_t m_state_parameter_mutexHandle;
-
-extern volatile uint16_t steering_wheel;
 
 void torque_manager(void *argument) {
 
@@ -60,7 +57,7 @@ void torque_manager(void *argument) {
 
 uint32_t rampa_torque() {
 	static uint32_t ref_torque_ant = 0;
-	uint32_t ref_torque = (modo_selecionado.torq_gain * throttle_percent) / 10;
+	uint32_t ref_torque = (get_global_var_value(SELECTED_MODE).torq_gain * get_global_var_value(THROTTLE_PERCENT)) / 10;
 
 	if (ref_torque_ant > TORQUE_INIT_LIMITE) {					    // verifica se a referencia
 		if (ref_torque > ref_torque_ant + INC_TORQUE) {				// ja passou do ponto de inflexao


### PR DESCRIPTION
Como discutido anteriormente, esse patch substitui as variáveis globais por queue de 1 elemento. Isso possibilita a sincronização automática dos dados sem precisar se preocupar com semáforos/mutexes. 

Foi feito de maneira a simplificar tanto o registro de novas variáveis globais quanto o uso. Para registrar, em `Core/Inc/CMSIS_extra/global_variables_handler.h`, deve-se seguir o padrão presente lá, criando um `typedef`, um valor default e registrando no `enum`. O requisito é: 
- escolha um nome para a variável. 
- Registre esse nome exatamente nos enums. 
- Adicione o sufixo `_t` nesse nome para criar o `typedef`. 
- Adicione o sufixo `_DEFAULT_VALUE` para criar o valor padrão.
Agora, em `Core/Src/CMSIS_extra/global_variables_handler.c`:
- Na função `void global_variables_init()`, siga o padrão para registrar a queue. O nome passado como argumento para a macro deve ser exatamente igual ao nome base, que foi registrado no `enum` (essa parte é essencial, porque depende-se dela para que a macro funcione).

Para utilizar as variáveis globais, há 2 formas.
- Usando as funções criadas:
   Para utilizar as variáveis com as funções criadas, é necessário criar uma instância da variável primeiro. Exemplo:
```cpp
THROTTLE_PERCENT_t throttle_percent;
get_global_var(THROTTLE_PERCENT, &throttle_percent);
// o valor da porcentagem do pedal, no momento em que se rodou a função acima, vai estar guardado na variável throttle_percent
throttle_percent = 0;
set_global_var(THROTTLE_PERCENT, &throttle_percent);
// agora throttle percent está zerado. Se outra tarefa executar um get_global_var depois desse ponto, receberá 0.
```
- Usando as macros:
   Para utilizar as variáveis com as macros criadas, **não** é necessário criar uma instância da variável primeiro. Exemplo:
```cpp
THROTTLE_PERCENT_t throttle_percent = get_global_var_value(THROTTLE_PERCENT);
// o valor da porcentagem do pedal, no momento em que se rodou a função acima, vai estar guardado na variável throttle_percent.
// seta o valor de porcentagem para 1% acima do lido e guardado em throttle_percent
set_global_var_value(THROTTLE_PERCENT, throttle_percent + 10);
// também pode-se colocar o valor diretamente:
set_global_var_value(THROTTLE_PERCENT, 0);
```
**Mas atenção**: deve-se lembra que essas são macros, não funções. Isso quer dizer que nem sempre funcionarão do jeito esperado, já que macros são basicamente `#defines` que aceitam argumentos para moldar as substituições.

Detalhe que eu não migrei todas as variáveis globais, mas já dá pra ter uma boa noção de como essa migração deve ser feita. Fica por conta suas migrar o resto rs.