### PR TITLE
Clang-format check

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,7 +1,5 @@
 # Action from: https://github.com/marketplace/actions/clang-format-check
 
-name: Formatting Check
-
 # Controls when the workflow will run
 on:
   push:
@@ -18,6 +16,7 @@ on:
 
 jobs:
   formatting-check:
+    name: Formatting Check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,28 @@
+name: clang-format Check
+
+# Controls when the workflow will run
+on:
+  push:
+    branches:
+      - master
+      - '**/*develop*'
+  pull_request:
+    branches:
+      - master
+      - '**/*develop*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check.
+      uses: jidicula/clang-format-action@v4.10.2
+      with:
+        clang-format-version: '13'
+        check-path: 'Core'
+        exclude-regex: '(freertos|main.c|stm32h7xx_)'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -25,4 +25,4 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: 'Core'
-        exclude-regex: '(freertos|main.c|stm32h7xx_)'
+        exclude-regex: '(freertos|main.c|main.h|stm32h7xx|syscalls.c|sysmem.c|FreeRTOSConfig.h)'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,3 +1,5 @@
+# Action from: https://github.com/marketplace/actions/clang-format-check
+
 name: clang-format Check
 
 # Controls when the workflow will run
@@ -23,6 +25,6 @@ jobs:
     - name: Run clang-format style check.
       uses: jidicula/clang-format-action@v4.10.2
       with:
-        clang-format-version: '13'
+        clang-format-version: '11'
         check-path: 'Core'
         exclude-regex: '(freertos|main.c|main.h|stm32h7xx|syscalls.c|sysmem.c|FreeRTOSConfig.h)'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Run clang-format style check.
       uses: jidicula/clang-format-action@v4.10.2
       with:
-        clang-format-version: '11'
+        clang-format-version: '15'
         check-path: 'Core'
         exclude-regex: '(freertos|main.c|main.h|stm32h7xx|syscalls.c|sysmem.c|FreeRTOSConfig.h)'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,7 @@
 # Action from: https://github.com/marketplace/actions/clang-format-check
 
+name: clang-format
+
 # Controls when the workflow will run
 on:
   push:
@@ -16,7 +18,7 @@ on:
 
 jobs:
   formatting-check:
-    name: Formatting Check
+    name: Check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,6 @@
 # Action from: https://github.com/marketplace/actions/clang-format-check
 
-name: clang-format Check
+name: Formatting Check
 
 # Controls when the workflow will run
 on:
@@ -18,7 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    name: Formatting Check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,4 +1,5 @@
 # Action from: https://github.com/marketplace/actions/clang-format-check
+# Placed in repository by Felipe Telles (felipe.melo.telles@gmail.com)
 
 name: clang-format
 
@@ -27,4 +28,5 @@ jobs:
       with:
         clang-format-version: '15'
         check-path: 'Core'
+        # In the following line all files exceptions should be defined
         exclude-regex: '(freertos|main.c|main.h|stm32h7xx|syscalls.c|sysmem.c|FreeRTOSConfig.h)'

--- a/Core/Inc/dynamic_controls/lateral_control.h
+++ b/Core/Inc/dynamic_controls/lateral_control.h
@@ -8,9 +8,7 @@
 #ifndef INC_DYNAMICCONTROLS_LATERAL_CONTROL_H_
 #define INC_DYNAMICCONTROLS_LATERAL_CONTROL_H_
 
-
 #include "stdint.h"
-
 
 #define LATERAL_DELAY 30
 
@@ -18,8 +16,8 @@
 #define HALF_GYRO     2000
 #define ADJUST_GYRO_R 1000
 #define ADJUST_GYRO_L 2000
-//#define ADJUST_STEERING 2000
-// lookup table
+// #define ADJUST_STEERING 2000
+//  lookup table
 #define Y0            ((-0.523598776 - 0.599520598) / 2)
 #define Y1            ((0.599520598 + 0.523598776) / 2)
 #define X0            (-1.941983885)
@@ -28,7 +26,6 @@
 #define KP_LATERAL    6.51864262048678
 #define KI_LATERAL    43.9160892044863
 #define TI_LATERAL    (KP_LATERAL / KI_LATERAL) // 0.14843404179579
-
 
 typedef struct {
     double torque_decrease[2];

--- a/Core/Inc/leds/rgb_led_handler.h
+++ b/Core/Inc/leds/rgb_led_handler.h
@@ -16,37 +16,21 @@
 #define RGB_BLINK_DELAY 200
 
 #define RGB_BLACK                                                                        \
-    (rgb_t) {                                                                              \
-        0, 0, 0                                                                          \
-    }
+    (rgb_t) { 0, 0, 0 }
 #define RGB_RED                                                                          \
-    (rgb_t) {                                                                              \
-        1, 0, 0                                                                          \
-    }
+    (rgb_t) { 1, 0, 0 }
 #define RGB_GREEN                                                                        \
-    (rgb_t) {                                                                              \
-        0, 1, 0                                                                          \
-    }
+    (rgb_t) { 0, 1, 0 }
 #define RGB_BLUE                                                                         \
-    (rgb_t) {                                                                              \
-        0, 0, 1                                                                          \
-    }
+    (rgb_t) { 0, 0, 1 }
 #define RGB_YELLOW                                                                       \
-    (rgb_t) {                                                                              \
-        1, 1, 0                                                                          \
-    }
+    (rgb_t) { 1, 1, 0 }
 #define RGB_PURBLE                                                                       \
-    (rgb_t) {                                                                              \
-        1, 0, 1                                                                          \
-    }
+    (rgb_t) { 1, 0, 1 }
 #define RGB_CYAN                                                                         \
-    (rgb_t) {                                                                              \
-        0, 1, 1                                                                          \
-    }
+    (rgb_t) { 0, 1, 1 }
 #define RGB_WHITE                                                                        \
-    (rgb_t) {                                                                              \
-        1, 1, 1                                                                          \
-    }
+    (rgb_t) { 1, 1, 1 }
 
 typedef enum { FIXED, BLINK200, NO_CHANGE } control_rgb_led_e;
 

--- a/Core/Src/datalogging/odometer_calc.c
+++ b/Core/Src/datalogging/odometer_calc.c
@@ -40,7 +40,7 @@ void odometer_calc() {
 
     for (;;) {
         ECU_ENABLE_BREAKPOINT_DEBUG();
-        
+
         wait_for_rtd();
         // Calculate and log distance traveled
         const SPEEDS_t speed_var = get_global_var_value(SPEEDS);

--- a/Core/Src/driver_settings/RTD.c
+++ b/Core/Src/driver_settings/RTD.c
@@ -91,7 +91,8 @@ bool can_RTD_be_enabled() {
     RACE_MODE_t race_mode                = get_global_var_value(RACE_MODE);
     // flag that indicates when the inverter precharge time has passed and the inverter is
     // ready
-    bool is_inverter_ready = get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY);
+    bool is_inverter_ready =
+        get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY);
     if (is_brake_active && !is_throttle_active && !error_flags && (race_mode != ERRO)
         && is_inverter_ready) {
         return true;

--- a/Core/Src/dynamic_controls/longitudinal_control.c
+++ b/Core/Src/dynamic_controls/longitudinal_control.c
@@ -7,9 +7,9 @@
 
 #include "dynamic_controls/longitudinal_control.h"
 
-#include "dynamic_controls/constants_control.h"
 #include "cmsis_os.h"
 #include "dynamic_controls/PID.h"
+#include "dynamic_controls/constants_control.h"
 #include "util/CMSIS_extra/global_variables_handler.h"
 #include "util/constants.h"
 #include "util/global_variables.h"
@@ -38,7 +38,8 @@ double wheel_control(uint8_t wheel_motor, SPEEDS_t speeds) {
     // speed of the car's center of mass
     cm_speed = (float)get_global_var_value(REAR_AVG_SPEED);
     // slip ratio of the selected wheel
-    slip = (((float)(speeds.wheels[controlled_wheels[wheel_motor].wheel]) - cm_speed) / cm_speed)
+    slip = (((float)(speeds.wheels[controlled_wheels[wheel_motor].wheel]) - cm_speed)
+            / cm_speed)
            * 100;
     // PID
     return (

--- a/Core/Src/util/initializers.c
+++ b/Core/Src/util/initializers.c
@@ -11,6 +11,7 @@
 #include "CAN/general_can.h"
 #include "CAN/inverter_can.h"
 #include "cmsis_os.h"
+#include "dynamic_controls/initializer_controls.h"
 #include "main.h"
 #include "stm32h7xx.h"
 #include "stm32h7xx_hal.h"
@@ -18,7 +19,6 @@
 #include "util/constants.h"
 #include "util/global_definitions.h"
 #include "util/global_variables.h"
-#include "dynamic_controls/initializer_controls.h"
 
 // inicializa prioridade dos ISRs para permitir chamada da API do RTOS de dentro dos ISRs
 //  mantendo a prioridade maxima de ISRs
@@ -126,10 +126,10 @@ void deInit_all_peripherals() {
 
 void init_ECU() {
     /* ### - 2 - Start calibration ############################################ */
-    if (HAL_ADCEx_Calibration_Start(&hadc1, ADC_CALIB_OFFSET, ADC_SINGLE_ENDED) != HAL_OK)
-        {
-            ;
-        }
+    if (HAL_ADCEx_Calibration_Start(&hadc1, ADC_CALIB_OFFSET, ADC_SINGLE_ENDED)
+        != HAL_OK) {
+        ;
+    }
     HAL_TIM_Base_Start(&htim2);
     init_ADC_DMA(&hadc1);
     init_CAN();


### PR DESCRIPTION
Mais um bot para avaliar o código antes dos reviewers rs.
O bot vai chegar se todos os arquivos na pasta Core/ (exceto os gerados pelo cube) estão formatados corretamente. 
O resultado pode ser visto ao clicar no check dele. Lá vai tá escrito: 

> Failed on file: \<nome do arquivo\>

Só corrigir o arquivo e o erro vai sair. A saída dele é bem verbosa e feia, pode ser feito um bot que cria um comentário igual o do clang-tidy, mas lá parece que a própria action que faz comentário, nesse caso teria que fazer na mão, pois não achei nenhum que faz comentário.

[Exemplo de check com falha](https://github.com/Tesla-UFMG/ECU/actions/runs/4119291456/jobs/7112785466)