### PR TITLE
Corrigindo nome de flags erradas e removendo todos os alertas do código.

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -53,6 +53,7 @@
 									<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
 									<listOptionValue builtIn="false" value="../Drivers/STM32H7xx_HAL_Driver/Inc"/>
 								</option>
+								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.warnings.extra.332186582" name="Enable extra warning flags (-Wextra)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.warnings.extra" useByScannerDiscovery="false" value="false" valueType="boolean"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.716971159" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1136912612" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">

--- a/Core/Inc/FreeRTOSConfig.h
+++ b/Core/Inc/FreeRTOSConfig.h
@@ -44,6 +44,7 @@
  *----------------------------------------------------------*/
 
 /* USER CODE BEGIN Includes */
+#include "hook_handlers.h"
 /* Section where include file can be added */
 /* USER CODE END Includes */
 

--- a/Core/Inc/driver_settings/RTD.h
+++ b/Core/Inc/driver_settings/RTD.h
@@ -8,7 +8,8 @@
 #ifndef INC_RTD_H_
 #define INC_RTD_H_
 
-#define tempo_sirene 1000
+// FSAE Rules: EV.10.5.2.a (2023)
+#define RTDS_TIME_MS 1000
 
 void exit_RTD();
 

--- a/Core/Inc/hook_handlers.h
+++ b/Core/Inc/hook_handlers.h
@@ -1,0 +1,13 @@
+/*
+ * hook_handlers.h
+ *
+ *  Created on: Apr 2, 2023
+ *      Author: feltell
+ */
+
+#ifndef HOOK_HANDLERS_H
+#define HOOK_HANDLERS_H
+
+void vAssertCalled(const char* pcFile, unsigned long ulLine);
+
+#endif /* HOOK_HANDLERS_H */

--- a/Core/Inc/util/CMSIS_extra/global_variables_handler.h
+++ b/Core/Inc/util/CMSIS_extra/global_variables_handler.h
@@ -27,7 +27,9 @@ typedef bool THROTTLE_STATUS_t;
 typedef modos SELECTED_MODE_t;
 
 #define SPEEDS_DEFAULT_VALUE                                                             \
-    { 0, 0, 0, 0 }
+    {                                                                                    \
+        { 0, 0, 0, 0 }                                                                   \
+    }
 #define FRONT_AVG_SPEED_DEFAULT_VALUE  0
 #define REAR_AVG_SPEED_DEFAULT_VALUE   0
 #define STEERING_WHEEL_DEFAULT_VALUE   0

--- a/Core/Inc/util/global_definitions.h
+++ b/Core/Inc/util/global_definitions.h
@@ -109,7 +109,7 @@ typedef enum {
 #define ODOMETER_SAVE_THREAD_FLAG                       (1 << 3)
 
 // ** ECU_control_flags **
-// Bellow are flags that are part of the ECU_control_flags, a 32 bit variable, they can be
+// Below are flags that are part of the ECU_control_flags, a 32 bit variable, they can be
 // used in all tasks and for datalogging. They are divided in four groups, general flags
 // (0 to 9), warning flags (10 to 15), soft errors flags (16 to 18) and hard errors flags
 // (19 to 32).

--- a/Core/Inc/util/global_definitions.h
+++ b/Core/Inc/util/global_definitions.h
@@ -101,16 +101,24 @@ typedef enum {
 
 #define APPS_PLAUSIBILITY_PERCENTAGE_TOLERANCE 10
 
-// Thread Flags
+// Thread Flags (Flags that are not in the ECU_control_flags and are only for
+// communication between two tasks)
 #define RTD_BTN_PRESSED_THREAD_FLAG                     (1 << 0)
 #define MODE_BTN_PRESSED_THREAD_FLAG                    (1 << 1)
 #define DYNAMIC_CONTROLS_CHOICE_BTN_PRESSED_THREAD_FLAG (1 << 2)
-#define RTD_THREAD_FLAG                                 (1 << 3)
-#define GENERAL_BUS_OFF_ERROR_THREAD_FLAG               (1 << 4)
-#define INVERTER_CAN_ACTIVE_THREAD_FLAG                 (1 << 5)
-#define INVERTER_READY_THREAD_FLAG                      (1 << 6)
-#define ODOMETER_SAVE_THREAD_FLAG                       (1 << 7)
-#define DYNAMIC_CONTROL_THREAD_FLAG                     (1 << 8)
+#define ODOMETER_SAVE_THREAD_FLAG                       (1 << 3)
+
+// ** ECU_control_flags **
+// Bellow are flags that are part of the ECU_control_flags, a 32 bit variable, they can be
+// used in all tasks and for datalogging. They are divided in four groups, general flags
+// (0 to 9), warning flags (10 to 15), soft errors flags (16 to 18) and hard errors flags
+// (19 to 32).
+
+// General flags
+#define RTD_FLAG                   (1 << 0)
+#define GENERAL_BUS_OFF_ERROR_FLAG (1 << 1)
+#define INVERTER_READY_FLAG        (1 << 2)
+#define DYNAMIC_CONTROL_FLAG       (1 << 3)
 
 // Warning flags	(No actions necessary)
 #define REGEN_WARN_FLAG           (1 << 10)
@@ -118,8 +126,8 @@ typedef enum {
 #define FLASH_SAVE_LIMIT_FLAG     (1 << 12)
 // Soft error flags (RTD keeps on, torque ref to inverter is set to 0)
 
-#define BSE_ERROR_FLAG  (1 << 16) // Regulamento: EV.5.7 (2021)
-#define APPS_ERROR_FLAG (1 << 17) // Regulamento: T.4.2 (2021)
+#define BSE_ERROR_FLAG  (1 << 16) // FSAE Rules: EV.5.7 (2021)
+#define APPS_ERROR_FLAG (1 << 17) // FSAE Rules: T.4.2 (2021)
 
 // Hard error flags (RTD disable)
 #define INVERTER_CAN_TRANSMIT_ERROR_FLAG (1 << 19)

--- a/Core/Src/CAN/CAN_handler.c
+++ b/Core/Src/CAN/CAN_handler.c
@@ -7,6 +7,7 @@
 
 #include "CAN/CAN_handler.h"
 
+#include "main.h"
 #include "util/error_treatment.h"
 #include "util/global_definitions.h"
 #include "util/global_instances.h"
@@ -22,29 +23,29 @@ void initialize_CAN(FDCAN_HandleTypeDef* hfdcan,
     if (HAL_FDCAN_ActivateNotification(hfdcan, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0)
         != HAL_OK) {
         /* Notification Error */
-        Error_Handler(); // NOLINT
+        Error_Handler();
     }
 
     if (HAL_FDCAN_ActivateNotification(hfdcan, FDCAN_IT_BUS_OFF, 0) != HAL_OK) {
         /* Notification Error */
-        Error_Handler(); // NOLINT
+        Error_Handler();
     }
 
     // Function to register the custom CAN receive callback
     if (HAL_FDCAN_RegisterRxFifo0Callback(hfdcan, CAN_receive_callback) != HAL_OK) {
         /* Callback Register Error */
-        Error_Handler(); // NOLINT
+        Error_Handler();
     }
 
     // Function to register the custom CAN error callback
     if (HAL_FDCAN_RegisterErrorStatusCallback(hfdcan, CAN_error_callback) != HAL_OK) {
         /* Callback Register Error */
-        Error_Handler(); // NOLINT
+        Error_Handler();
     }
 
     if (HAL_FDCAN_Start(hfdcan) != HAL_OK) {
         /* Start Error */
-        Error_Handler(); // NOLINT
+        Error_Handler();
     }
 
     TxHeader->IdType              = FDCAN_STANDARD_ID;

--- a/Core/Src/CAN/general_can.c
+++ b/Core/Src/CAN/general_can.c
@@ -66,12 +66,12 @@ void CAN_general_receive_callback(FDCAN_HandleTypeDef* hfdcan, uint32_t RxFifo0I
     }
 }
 
-// callback que sera chamado quando ouver erro de BUSOFF da CAN
+// Callback for BUSOFF error in general can.
 void CAN_general_error_callback(FDCAN_HandleTypeDef* hfdcan, uint32_t ErrorStatusITs) {
     if (ErrorStatusITs | FDCAN_IT_BUS_OFF) {
-        // seta a flag de evento para datalog
-        osEventFlagsSet(e_ECU_control_flagsHandle, GENERAL_BUS_OFF_ERROR_THREAD_FLAG);
-        // limpa o bit de INIT da CAN, voltando a receber mensagem
+        // Sets the flag for datalogging
+        osEventFlagsSet(e_ECU_control_flagsHandle, GENERAL_BUS_OFF_ERROR_FLAG);
+        // Clear INIT bit, so can communication is reestablished
         CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_INIT);
     }
 }

--- a/Core/Src/CAN/general_can.c
+++ b/Core/Src/CAN/general_can.c
@@ -42,7 +42,8 @@ void CAN_general_receive_callback(FDCAN_HandleTypeDef* hfdcan, uint32_t RxFifo0I
     uint8_t rx_data[8];
 
     if ((RxFifo0ITs & FDCAN_IT_RX_FIFO0_NEW_MESSAGE) != RESET) {
-        if (HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &RxHeader, rx_data) != HAL_OK) {
+        if (HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &RxHeader, rx_data)
+            != HAL_OK) {
             /* Reception Error */
             Error_Handler();
         }

--- a/Core/Src/CAN/general_can_data_manager.c
+++ b/Core/Src/CAN/general_can_data_manager.c
@@ -23,9 +23,9 @@ general_can_vars_e general_get_var_name_from_id_and_pos(uint32_t id, int pos) {
 #define ENTRY(a, b, c)                                                                   \
     if (id == (b) && pos == (c))                                                         \
         return a;                                                                        \
-    else
-    // NOLINTNEXTLINE
-    VARIABLES_GENERAL_CAN_RX_IDS;
+    else {                                                                               \
+        VARIABLES_GENERAL_CAN_RX_IDS;                                                    \
+    }
 #undef ENTRY
     return -1;
 }

--- a/Core/Src/CAN/inverter_can_data_manager.c
+++ b/Core/Src/CAN/inverter_can_data_manager.c
@@ -23,9 +23,9 @@ can_vars_inverter_e inverter_get_var_name_from_id_and_pos(uint32_t id, int pos) 
 #define ENTRY(a, b, c)                                                                   \
     if (id == (b) && pos == (c))                                                         \
         return a;                                                                        \
-    else
-    // NOLINTNEXTLINE
-    VARIABLES_INVERTER_CAN_RX;
+    else {                                                                               \
+        VARIABLES_INVERTER_CAN_RX;                                                       \
+    }
 #undef ENTRY
     return -1;
 }

--- a/Core/Src/CAN/inverter_can_monitor.c
+++ b/Core/Src/CAN/inverter_can_monitor.c
@@ -65,7 +65,7 @@ void left_inv_error_callback() {
 
     issue_error(LEFT_INVERTER_COMM_ERROR_FLAG, /*should_set_control_event_flag=*/true);
 
-    osEventFlagsClear(e_ECU_control_flagsHandle, INVERTER_READY_THREAD_FLAG);
+    osEventFlagsClear(e_ECU_control_flagsHandle, INVERTER_READY_FLAG);
 
     osTimerStop(tim_inverter_readyHandle);
 }
@@ -76,7 +76,7 @@ void right_inv_error_callback() {
 
     issue_error(RIGHT_INVERTER_COMM_ERROR_FLAG, /*should_set_control_event_flag=*/true);
 
-    osEventFlagsClear(e_ECU_control_flagsHandle, INVERTER_READY_THREAD_FLAG);
+    osEventFlagsClear(e_ECU_control_flagsHandle, INVERTER_READY_FLAG);
 
     osTimerStop(tim_inverter_readyHandle);
 }
@@ -84,7 +84,7 @@ void right_inv_error_callback() {
 void precharge_monitor() {
     // start the timer only when the flag is reseted and the timer is not alredy
     // running to avoid restarting the timer
-    if (!get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY_THREAD_FLAG)) {
+    if (!get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY_FLAG)) {
         if (!osTimerIsRunning(tim_inverter_readyHandle)) {
             // timer to set a flag to indicate when the inverter is ready after the
             // precharge period
@@ -102,5 +102,5 @@ void inverter_BUS_OFF_error_callback(void* argument) {
 // the flag wil be setted after the precharge time has passed
 void inverter_ready_callback(void* argument) {
     UNUSED(argument);
-    osEventFlagsSet(e_ECU_control_flagsHandle, INVERTER_READY_THREAD_FLAG);
+    osEventFlagsSet(e_ECU_control_flagsHandle, INVERTER_READY_FLAG);
 }

--- a/Core/Src/CAN/inverter_can_monitor.c
+++ b/Core/Src/CAN/inverter_can_monitor.c
@@ -13,10 +13,8 @@
 #include "util/global_instances.h"
 #include "util/util.h"
 
-void precharge_monitor();
-void left_inv_error_callback();
-void right_inv_error_callback();
-void inverter_can_diff(uint32_t id);
+static void precharge_monitor();
+static void inverter_can_diff(uint32_t id);
 
 void inverter_comm_error(void* argument) {
     UNUSED(argument);
@@ -38,7 +36,7 @@ void inverter_comm_error(void* argument) {
     }
 }
 
-void inverter_can_diff(uint32_t id) {
+static void inverter_can_diff(uint32_t id) {
 
     // Restart the timer and clear the error if any message on each inverter
     // gets received
@@ -81,7 +79,7 @@ void right_inv_error_callback() {
     osTimerStop(tim_inverter_readyHandle);
 }
 
-void precharge_monitor() {
+static void precharge_monitor() {
     // start the timer only when the flag is reseted and the timer is not alredy
     // running to avoid restarting the timer
     if (!get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY_FLAG)) {

--- a/Core/Src/driver_settings/RTD.c
+++ b/Core/Src/driver_settings/RTD.c
@@ -90,7 +90,7 @@ bool can_RTD_be_enabled() {
     // flag that indicates when the inverter precharge time has passed and the inverter is
     // ready
     bool is_inverter_ready =
-        get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY_THREAD_FLAG);
+        get_individual_flag(e_ECU_control_flagsHandle, INVERTER_READY_FLAG);
     if (is_brake_active && !is_throttle_active && !error_flags && (race_mode != ERRO)
         && is_inverter_ready) {
         return true;

--- a/Core/Src/driver_settings/RTD.c
+++ b/Core/Src/driver_settings/RTD.c
@@ -16,7 +16,7 @@
 #include "util/global_variables.h"
 #include "util/util.h"
 
-void aciona_sirene();
+void activate_RTDS();
 bool can_RTD_be_enabled();
 void set_RTD();
 
@@ -48,7 +48,7 @@ void exit_RTD() {
     set_global_var_value(RACE_MODE, ERRO);
     set_rgb_led(get_global_var_value(SELECTED_MODE).cor, BLINK200);
     // limpa flag de RTD
-    osEventFlagsClear(e_ECU_control_flagsHandle, RTD_THREAD_FLAG);
+    osEventFlagsClear(e_ECU_control_flagsHandle, RTD_FLAG);
     osThreadFlagsSet(t_odometer_saveHandle, ODOMETER_SAVE_THREAD_FLAG);
 }
 
@@ -99,14 +99,14 @@ bool can_RTD_be_enabled() {
 }
 
 void set_RTD() {
-    // Seta flag de RTD
-    osEventFlagsSet(e_ECU_control_flagsHandle, RTD_THREAD_FLAG);
+    osEventFlagsSet(e_ECU_control_flagsHandle, RTD_FLAG);
     set_rgb_led(get_global_var_value(SELECTED_MODE).cor, FIXED);
-    aciona_sirene();
+    activate_RTDS();
 }
 
-void aciona_sirene() {
+// Ready to drive sound. As defined by FSAE Rules: EV.10.5 (2023)
+void activate_RTDS() {
     HAL_GPIO_WritePin(C_RTDS_GPIO_Port, C_RTDS_Pin, GPIO_PIN_SET);
-    osDelay(tempo_sirene);
+    osDelay(RTDS_TIME_MS);
     HAL_GPIO_WritePin(C_RTDS_GPIO_Port, C_RTDS_Pin, GPIO_PIN_RESET);
 }

--- a/Core/Src/driver_settings/RTD.c
+++ b/Core/Src/driver_settings/RTD.c
@@ -16,9 +16,9 @@
 #include "util/global_variables.h"
 #include "util/util.h"
 
-void activate_RTDS();
-bool can_RTD_be_enabled();
-void set_RTD();
+static void activate_RTDS();
+static bool can_RTD_be_enabled();
+static void set_RTD();
 
 void RTD(void* argument) {
     UNUSED(argument);
@@ -80,7 +80,7 @@ void exit_RTD() {
  * activation after a timer which is started when the inverter sends its first message.
  *      TODO: Allow RTD activation from the status check of the AIRs.
  */
-bool can_RTD_be_enabled() {
+static bool can_RTD_be_enabled() {
     // obtem todas as flags e filtra apenas flags de erros severos, ignorando as outras
     uint32_t error_flags = osEventFlagsGet(e_ECU_control_flagsHandle);
     error_flags &= ALL_SEVERE_ERROR_FLAG;
@@ -98,14 +98,14 @@ bool can_RTD_be_enabled() {
     return false;
 }
 
-void set_RTD() {
+static void set_RTD() {
     osEventFlagsSet(e_ECU_control_flagsHandle, RTD_FLAG);
     set_rgb_led(get_global_var_value(SELECTED_MODE).cor, FIXED);
     activate_RTDS();
 }
 
 // Ready to drive sound. As defined by FSAE Rules: EV.10.5 (2023)
-void activate_RTDS() {
+static void activate_RTDS() {
     HAL_GPIO_WritePin(C_RTDS_GPIO_Port, C_RTDS_Pin, GPIO_PIN_SET);
     osDelay(RTDS_TIME_MS);
     HAL_GPIO_WritePin(C_RTDS_GPIO_Port, C_RTDS_Pin, GPIO_PIN_RESET);

--- a/Core/Src/driver_settings/dynamic_controls_choice.c
+++ b/Core/Src/driver_settings/dynamic_controls_choice.c
@@ -29,12 +29,12 @@ void dynamic_controls_choice(void* argument) {
             continue;
         }
         const bool is_DYNAMIC_CONTROL_active =
-            get_individual_flag(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_THREAD_FLAG);
+            get_individual_flag(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_FLAG);
 
         if (!is_DYNAMIC_CONTROL_active) {
-            osEventFlagsSet(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_THREAD_FLAG);
+            osEventFlagsSet(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_FLAG);
         } else {
-            osEventFlagsClear(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_THREAD_FLAG);
+            osEventFlagsClear(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_FLAG);
         }
     }
 }

--- a/Core/Src/driver_settings/modo.c
+++ b/Core/Src/driver_settings/modo.c
@@ -39,7 +39,7 @@ void seleciona_modo(void* argument) {
             }
 
             set_rgb_led(get_global_var_value(SELECTED_MODE).cor, BLINK200);
-            osEventFlagsClear(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_THREAD_FLAG);
+            osEventFlagsClear(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_FLAG);
         }
         // todo: dataloggar modos
     }

--- a/Core/Src/dynamic_controls/PID.c
+++ b/Core/Src/dynamic_controls/PID.c
@@ -7,6 +7,8 @@
 
 #include "dynamic_controls/PID.h"
 
+#include "string.h"
+
 void PID_recalculate_constants(PID_t* pid) {
     pid->C0 = -pid->Kp;
     pid->C1 = pid->Kp + pid->Kp * pid->sample_period / pid->Ti;

--- a/Core/Src/hook_handlers.c
+++ b/Core/Src/hook_handlers.c
@@ -4,6 +4,8 @@
  *  Created on: Feb 1, 2021
  *      Author: renanmoreira
  */
+#include "hook_handlers.h"
+
 #include "cmsis_os.h"
 #include "stm32h7xx.h"
 #include "util/util.h"

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1197,6 +1197,7 @@ static void MX_GPIO_Init(void)
 /* USER CODE END Header_main_task */
 __weak void main_task(void *argument)
 {
+  UNUSED(argument);
   /* USER CODE BEGIN 5 */
   /* Infinite loop */
   for(;;)

--- a/Core/Src/sensors/APPS.c
+++ b/Core/Src/sensors/APPS.c
@@ -46,12 +46,12 @@ void APPS_read(void* argument) {
         bse         = ADC_DMA_buffer[BRAKE_E];
 
         // valores de referencia e parametros para o calculo da porcentagem
-        const static apps_ref apps1_ref = {.deadzone_lower_limit = APPS1_LOWER_DEADZONE,
+        static const apps_ref apps1_ref = {.deadzone_lower_limit = APPS1_LOWER_DEADZONE,
                                            .deadzone_upper_limit = APPS1_UPPER_DEADZONE,
                                            .adjust_parameters_slope = APPS1_ADJUST_SLOPE,
                                            .adjust_parameters_intercept =
                                                APPS1_ADJUST_INTERCEPT};
-        const static apps_ref apps2_ref = {.deadzone_lower_limit = APPS2_LOWER_DEADZONE,
+        static const apps_ref apps2_ref = {.deadzone_lower_limit = APPS2_LOWER_DEADZONE,
                                            .deadzone_upper_limit = APPS2_UPPER_DEADZONE,
                                            .adjust_parameters_slope = APPS2_ADJUST_SLOPE,
                                            .adjust_parameters_intercept =

--- a/Core/Src/torque_command/torque_manager.c
+++ b/Core/Src/torque_command/torque_manager.c
@@ -34,7 +34,7 @@ void torque_manager(void* argument) {
         void select_dynamic_control(bool is_DYNAMIC_CONTROL_active);
 
         const bool is_DYNAMIC_CONTROL_active =
-            get_individual_flag(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_THREAD_FLAG);
+            get_individual_flag(e_ECU_control_flagsHandle, DYNAMIC_CONTROL_FLAG);
 
         select_dynamic_control(is_DYNAMIC_CONTROL_active);
 

--- a/Core/Src/torque_command/torque_parameters.c
+++ b/Core/Src/torque_command/torque_parameters.c
@@ -110,7 +110,7 @@ void torque_parameters(void* argument) {
 
         bool disable;
         // disable will only be FALSE when RTD_FLAG is setted
-        disable = !get_individual_flag(e_ECU_control_flagsHandle, RTD_THREAD_FLAG);
+        disable = !is_RTD_active();
 
         switch (osMessageQueueGet(q_ref_torque_messageHandle, &ref_torque_message, 0,
                                   TORQUE_PARAMETERS_DELAY)) {

--- a/Core/Src/util/util.c
+++ b/Core/Src/util/util.c
@@ -57,12 +57,11 @@ bool is_the_car_stationary() {
 }
 
 void wait_for_rtd() {
-    osEventFlagsWait(e_ECU_control_flagsHandle, RTD_THREAD_FLAG, osFlagsNoClear,
-                     osWaitForever);
+    osEventFlagsWait(e_ECU_control_flagsHandle, RTD_FLAG, osFlagsNoClear, osWaitForever);
 }
 
 bool is_RTD_active() {
-    bool is_RTD_active = get_individual_flag(e_ECU_control_flagsHandle, RTD_THREAD_FLAG);
+    const bool is_RTD_active = get_individual_flag(e_ECU_control_flagsHandle, RTD_FLAG);
 
     return (is_RTD_active);
 }


### PR DESCRIPTION
Em algum PR passado os nomes das flags gerais misturaram e foi colocado o label de THREAD_FLAGS nelas. Foi colocado um comentário para explicar as diferenças entre thread flags e general flags para tentar evitar essa confusão no futuro.

Aproveitei e corrigi alguns erros bobos que percebi (nome no padrão errado, funções e variáveis sem static). Só arrumei o que percebi, ainda deve ter mais erros desses.

Também removi todos os avisos e removi alguns avisos extras (-Wextras)